### PR TITLE
fix(ui): 解决嵌套DataFormLayout的样式问题

### DIFF
--- a/packages/layout/src/components/reasonPopconfirm/index.tsx
+++ b/packages/layout/src/components/reasonPopconfirm/index.tsx
@@ -1,0 +1,71 @@
+/**
+ * 可填写原因的确认气泡框
+ */
+
+import React, { useState } from 'react';
+import { Popover, Button, Input, message, Form } from 'antd';
+import { BlIcon } from '@blacklake-web/component';
+import { hidePopover } from '../../utils';
+import './styles.less';
+
+export type ReasonConformCallback = (reason: string) => Promise<void>;
+export interface ReasonPopconfirmProps {
+  /** 操作名 */
+  opName: string;
+  /** 点击确认后的操作 */
+  onConfirm: ReasonConformCallback;
+  /** 原因的最大输入字数 */
+  reasonMaxLength?: number;
+  /** 原因是否必填 */
+  reasonRequired?: boolean;
+}
+
+const PopReasonConfirm: React.FC<ReasonPopconfirmProps> = ({
+  opName,
+  onConfirm,
+  reasonMaxLength = 1000,
+  reasonRequired = false,
+  children,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [form] = Form.useForm();
+
+  const onOk = () => {
+    form.validateFields().then(() => {
+      setLoading(true);
+      onConfirm(form.getFieldValue('reason'))
+        .then(() => {
+          message.success(`${opName}成功！`);
+          setLoading(false);
+          hidePopover();
+        })
+        .catch(() => setLoading(false));
+    });
+  };
+  const content = (
+    <div className="bl-pop-reason-confirm">
+      <div style={{ marginBottom: 16 }}>
+        <BlIcon type="iconmianxingtixing-jingshi" style={{ color: '#FAAD14', marginRight: 8, fontSize: 16 }} />
+        你确定要{opName}吗？
+      </div>
+      <Form form={form}>
+        <Form.Item
+          name="reason"
+          rules={[{ required: reasonRequired, message: `${opName}原因必填` }]}
+        >
+          <Input.TextArea className="ant-input" placeholder={`请输入${opName}原因`} maxLength={reasonMaxLength} />
+        </Form.Item>
+      </Form>
+      <div className="bl-pop-reason-confirm-footer" >
+        <Button type="default" size="small" onClick={hidePopover}>取消</Button>
+        <Button type="primary" size="small" loading={loading} onClick={onOk}>确定</Button>
+      </div>
+    </div>
+  );
+
+  return (
+    <Popover content={content} placement="topRight" trigger="click" destroyTooltipOnHide>{children}</Popover>
+  );
+};
+
+export default PopReasonConfirm;

--- a/packages/layout/src/components/reasonPopconfirm/styles.less
+++ b/packages/layout/src/components/reasonPopconfirm/styles.less
@@ -1,0 +1,22 @@
+.bl-pop-reason-confirm {
+  color: rgba(0,0,0,.65);
+
+  .ant-input {
+    width: 296px;
+    min-height: 86px;
+  }
+
+  &-footer {
+    margin: 12px 0 8px;
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+
+    .ant-btn {
+      padding: 0 8px;
+    }
+    .ant-btn-default {
+      color: rgba(0,0,0,.65);
+    }
+  }
+}

--- a/packages/layout/src/dataForm/DataFormLayout.tsx
+++ b/packages/layout/src/dataForm/DataFormLayout.tsx
@@ -23,6 +23,8 @@ const BlDataFormLayout: React.FC<
     formProps,
     infoBlockStyleProps,
     fieldPermission,
+    bodyClassName,
+    getAdaptiveContainer,
     ...footerProps
   } = props;
 
@@ -45,6 +47,8 @@ const BlDataFormLayout: React.FC<
               formProps={formProps}
               infoBlockStyleProps={infoBlockStyleProps}
               fieldPermission={fieldPermission}
+              bodyClassName={bodyClassName}
+              getAdaptiveContainer={getAdaptiveContainer}
             />
           ) : null}
           {children}

--- a/packages/layout/src/dataForm/index.md
+++ b/packages/layout/src/dataForm/index.md
@@ -255,12 +255,60 @@ export default () => {
     ],
   };
 
+  const nestingInfo: DataFormLayoutInfoBlock = {
+    title: '嵌套格式',
+    items: [
+      {
+        label: '',
+        isFullLine: true,
+        render: () => {
+          return (
+            <div style={{ padding: '0px 24px' }}>
+              <DataFormLayout
+                form={modalForm}
+                title=""
+                footer={false}
+                info={[
+                  {
+                    title: '基本信息',
+                    column: 1,
+                    items: [
+                      {
+                        label: '名称',
+                        name: 'nesting-name',
+                        render: () => (
+                          <Select
+                            placeholder="请输入"
+                            allowClear
+                            options={[
+                              { label: 'name1', value: '1' },
+                              { label: 'name2', value: '2' },
+                            ]}
+                          />
+                        ),
+                      },
+                      {
+                        label: '年龄',
+                        name: 'nesting-age',
+                        render: () => <InputNumber placeholder="请输入" />,
+                      },
+                    ]
+                  }
+                ]}
+                getAdaptiveContainer={() => document.querySelector('.parent-data-form')}
+              />
+            </div>
+          );
+        },
+      },
+    ],
+  };
   return (
     <div style={{ border: '1px solid #d8d8d8', position: 'relative' }}>
       <DataFormLayout
         form={modalForm}
         title="新建字段"
-        info={[baseInfo, otherInfo, specialInfo]}
+        info={[baseInfo, otherInfo, specialInfo, nestingInfo]}
         loading={loading}
         fieldPermission={{
           encoding: 'xxxxx',
@@ -271,6 +319,7 @@ export default () => {
           const value = await modalForm?.validateFields();
           console.log('%c [ value ]-220', 'font-size:px; color:#bf2c9f;', value);
         }}
+        bodyClassName="parent-data-form"
       />
     </div>
   );

--- a/packages/layout/src/recordList/components/RecordListBody.tsx
+++ b/packages/layout/src/recordList/components/RecordListBody.tsx
@@ -5,6 +5,7 @@ import { Button, Dropdown, Menu, Popconfirm, PopconfirmProps, TableProps } from 
 import { BlColumnsType, BlTable, BlIcon } from '@blacklake-web/component';
 import { SortOrder } from 'antd/lib/table/interface';
 //
+import ReasonPopconfirm, { ReasonConformCallback } from '../../components/reasonPopconfirm';
 import {
   BL_SELECTED_ALL,
   ListLayoutContext,
@@ -344,28 +345,46 @@ const RecordListBody = <RecordType extends object = any>(
   const renderButton = (item: OperationListItem) => {
     const disabled = item?.disabled ?? false;
 
-    if (item?.popconfirm) {
-      const defaultPopconfirm: PopconfirmProps = {
-        placement: 'topRight',
-        okText: '确定',
-        cancelText: '取消',
-        title: `确定要${item.title}吗?`,
-      };
-      const customPopconfirm = _.isObject(item?.popconfirm) ? item?.popconfirm : {};
-
-      return (
-        <Popconfirm
-          key={item.title}
-          {...defaultPopconfirm}
-          {...customPopconfirm}
-          disabled={disabled}
-          onConfirm={item.onClick}
-        >
-          <Button type="link" disabled={disabled}>
-            {item.title}
-          </Button>
-        </Popconfirm>
-      );
+    if (!disabled) {
+      if (item?.popconfirm) {
+        const defaultPopconfirm: PopconfirmProps = {
+          placement: 'topRight',
+          okText: '确定',
+          cancelText: '取消',
+          title: `确定要${item.title}吗?`,
+        };
+        const customPopconfirm = _.isObject(item?.popconfirm) ? item?.popconfirm : {};
+  
+        return (
+          <Popconfirm
+            key={item.title}
+            {...defaultPopconfirm}
+            {...customPopconfirm}
+            disabled={disabled}
+            onConfirm={item.onClick}
+          >
+            <Button key={item.title} type="link" disabled={disabled}>
+              {item.title}
+            </Button>
+          </Popconfirm>
+        );
+      }
+      if (item?.reasonconfirm) {
+        const reasonconfirmProps = _.isPlainObject(item.reasonconfirm)
+          ? item.reasonconfirm
+          : {};
+        return (
+          <ReasonPopconfirm
+            opName={item.title}
+            onConfirm={item.onClick as unknown as ReasonConformCallback}
+            {...reasonconfirmProps}
+          >
+            <Button key={item.title} type="link" disabled={disabled}>
+              {item.title}
+            </Button>
+          </ReasonPopconfirm>
+        );
+      }
     }
     return (
       <Button key={item.title} type="link" disabled={disabled} onClick={item?.onClick}>

--- a/packages/layout/src/recordList/index.md
+++ b/packages/layout/src/recordList/index.md
@@ -16,6 +16,15 @@ import React, { useState, useEffect } from 'react';
 import { Button, message } from 'antd';
 import { RecordListLayout, FilterFieldType } from '@blacklake-web/layout';
 
+const mockAPI = (params) => {
+  console.log(params);
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      Math.random() > 0.2 ? resolve() : reject();
+    }, 500);
+  });
+};
+
 export default () => {
   const [selectedKeys, setSelectedKeys] = useState([]);
   const [dataSource, setDataSource] = useState([]);
@@ -25,14 +34,14 @@ export default () => {
     const dataSource = [];
     for (let i = 1; i < 50; i++) {
       const item = {
+        id: i,
         name: `name_${i}`,
         sex: `sex_${i}`,
-        old: `old_${i}`,
+        age: Math.floor(Math.random() * 20) + 18,
         job: `job_${i}`,
         school: `school_${i}`,
         phone: `phone_${i}`,
         qq: `qq_${i}`,
-        children: [],
       };
       dataSource.push(item);
     }
@@ -69,25 +78,7 @@ export default () => {
     console.log('请求参数：', params);
     return new Promise((resolve, reject) => {
       setTimeout(() => {
-        const data = () => {
-          const dataSource = [];
-          for (let i = 1; i < 50; i++) {
-            const item = {
-              name: `name_${i}`,
-              sex: `sex_${i}`,
-              age: Math.floor(Math.random() * 20) + 18,
-              job: `job_${i}`,
-              school: `school_${i}`,
-              phone: `phone_${i}`,
-              qq: `qq_${i}`,
-            };
-            dataSource.push(item);
-          }
-          return dataSource;
-        };
-
         const list = data();
-
         const data2 = {
           data: {
             list,
@@ -200,7 +191,12 @@ export default () => {
         disabled: idx % 2 === 0,
         onClick: () => message.info(`编辑 ${record.name}`),
       },
-      { title: '删除', disabled: true, onClick: () => message.warn(`删除 ${record.name}`) },
+      {
+        title: '删除',
+        disabled: idx % 2 === 0,
+        reasonconfirm: true,
+        onClick: (reason) => mockAPI({ id: record.id, reason }),
+      },
       {
         title: '操作记录',
         auth: 'OP_RECORD_VIEW',

--- a/packages/layout/src/recordList/index.ts
+++ b/packages/layout/src/recordList/index.ts
@@ -3,8 +3,8 @@ import RecordListLayout, {
 } from './RecordListLayout';
 import { BL_SELECTED_ALL, KNOWN_EMPTY_LIST_PARAM } from './constants';
 
-import { FormatDataToQueryData, FilterItem } from './recordListLayout.type';
+import { FormatDataToQueryData, FilterItem, OperationListItem } from './recordListLayout.type';
 
 export { RecordListLayout, BL_SELECTED_ALL, KNOWN_EMPTY_LIST_PARAM };
 
-export type { FormatDataToQueryData, FilterItem, RecordListLayoutProps };
+export type { FormatDataToQueryData, FilterItem, RecordListLayoutProps, OperationListItem };

--- a/packages/layout/src/recordList/recordListLayout.type.ts
+++ b/packages/layout/src/recordList/recordListLayout.type.ts
@@ -1,6 +1,7 @@
 import { Dispatch } from 'react';
 import { SelectProps, InputProps, DatePickerProps, PopconfirmProps } from 'antd';
 import { LIST_REDUCER_TYPE } from './constants';
+import type { ReasonConformCallback, ReasonPopconfirmProps } from '../components/reasonPopconfirm';
 
 export type FilterData = {
   [index: string]: any;
@@ -97,8 +98,10 @@ export type OperationListItem = {
   auth?: string;
   /** 是否禁用 */
   disabled?: boolean;
-  /** 点击回调 */
-  onClick: () => void;
+  /** 点击回调。如果使用了二次确认弹窗，需返回一个Promise */
+  onClick: (...args: any) => void | ReasonConformCallback;
   /** 二次确认弹窗 */
   popconfirm?: PopconfirmProps;
+  /** 填写原因的二次确认弹窗 */
+  reasonconfirm?: boolean | Omit<ReasonPopconfirmProps, 'opName' | 'onConfirm'>;
 };

--- a/packages/layout/src/utils.ts
+++ b/packages/layout/src/utils.ts
@@ -9,3 +9,8 @@ import _ from 'lodash';
 export const filterListAuth = <T extends { auth?: string }>(list: T[], userAuth: string[]) => {
   return _.filter(list, ({ auth }) => !auth || userAuth.includes(auth));
 };
+
+/**
+ * 隐藏非受控的Popover
+ */
+export const hidePopover = () => document.dispatchEvent(new MouseEvent('mousedown'));


### PR DESCRIPTION
问题描述：

在嵌套使用`<DataFormLayout>`的情况下，内、外层`<DataFormLayout>`监听的宽度变化DOM元素是各自的`<DataFormLayoutBody>`的根节点`<div>`。

由于padding的存在，这两个`<div>`的宽度不一致，这就导致存在一个特定的宽度区间，当浏览器视口宽度恰好落在这个区间时，外层已经切换到2列布局，而内层还是单列布局。

但css样式是内外层共享的，内层由于单列和2列布局的样式同时生效，会出现奇葩的样式问题。

所以决定加一个`getAdaptiveContainer`属性以及配套的 `bodyClassName`属性，以解决这个问题。用法写在`index.md`里了。