### PR TITLE
fix(blsortformlist): footer无内容时不渲染

### DIFF
--- a/packages/component/src/BlSortFormList/BlSortFormList.tsx
+++ b/packages/component/src/BlSortFormList/BlSortFormList.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Input, Form, FormInstance, Button, Popover, Space, Tooltip } from 'antd';
+import { Input, Form, FormInstance, Button, Popover, Space, Tooltip, FormProps } from 'antd';
 import { FormListFieldData, FormListProps } from 'antd/lib/form/FormList';
 import { ColumnProps, TableProps } from 'antd/lib/table';
 import { SortableContainer, SortableElement, SortableHandle } from 'react-sortable-hoc';
@@ -15,6 +15,10 @@ export interface BlSortFormListProps {
    * Form 实例
    */
   form?: FormInstance;
+  /**
+   * 如果传入Form实例，可自定义props
+   */
+  formProps?: Omit<FormProps, 'form'>;
   /**
    * list 字段名称
    */
@@ -149,6 +153,7 @@ export const formatDeleteListToApi = (deleteListFormValue?: {
 const BlSortFormList = (props: BlSortFormListProps) => {
   const {
     form: propsForm,
+    formProps = {},
     name,
     renderColumns,
     isNeedDrag = true,
@@ -426,6 +431,7 @@ const BlSortFormList = (props: BlSortFormListProps) => {
     });
   };
 
+  const hasFooter = isNeedAdd || isNeedBatchAdd || !_.isNil(extraButton);
   const renderFooter = (
     add: (defaultValue?: any, insertIndex?: number | undefined) => void,
     data: FormListFieldData[],
@@ -539,7 +545,7 @@ const BlSortFormList = (props: BlSortFormListProps) => {
                   pagination={false}
                   columns={getColumns()}
                   dataSource={data}
-                  footer={() => renderFooter(add, fields)}
+                  footer={hasFooter ? () => renderFooter(add, fields) : undefined}
                   rowKey={(field) => field?.key}
                   id="attrTable"
                   components={
@@ -565,7 +571,7 @@ const BlSortFormList = (props: BlSortFormListProps) => {
   };
 
   const renderWithForm = () => {
-    return <Form form={propsForm}>{renderBase()}</Form>;
+    return <Form form={propsForm} {...formProps}>{renderBase()}</Form>;
   };
 
   return propsForm ? renderWithForm() : renderBase();

--- a/packages/component/src/BlSortFormList/index.md
+++ b/packages/component/src/BlSortFormList/index.md
@@ -114,4 +114,70 @@ export default () => {
 };
 ```
 
+```tsx
+/**
+ * title: 纯排序列表
+ * desc: 在只需排序无需编辑的场景使用
+ */
+
+import React, { useEffect } from 'react';
+import { Form, Input, InputNumber, Select, Button } from 'antd';
+import { BlSortFormList } from '@blacklake-web/component';
+
+export default () => {
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    form.setFieldsValue({
+      list: [
+        { id: 0, name: 'name_0' },
+        { id: 1, name: 'name_1' },
+        { id: 2, name: 'name_2' },
+        { id: 3, name: 'name_3' },
+        { id: 4, name: 'name_4' },
+      ],
+    });
+  }, []);
+
+  return (
+    <div>
+      <BlSortFormList
+        name="list"
+        form={form}
+        isNeedAdd={false}
+        isNeedDelete={false}
+        tableProps={{ showHeader: false }}
+        renderColumns={() => {
+          return [
+            {
+              title: '名称',
+              dataIndex: 'name',
+              render: (text, field) => (
+                <Form.Item
+                  name={[field.name, 'name']}
+                  fieldKey={[field.fieldKey, 'name']}
+                  style={{ marginBottom: '0' }}
+                  rules={[{ required: true, message: '名称不能为空' }]}
+                >
+                  <Input disabled />
+                </Form.Item>
+              ),
+            },
+          ];
+        }}
+      />
+      <div style={{ marginTop: 16, textAlign: 'center' }}>
+        <Button
+          type="primary"
+          onClick={() => {
+            console.log(form.getFieldsValue().list.map(it => it.name));
+          }}
+        >
+          提交
+        </Button>
+      </div>
+    </div>
+  );
+};
+```
 <API />


### PR DESCRIPTION
Antd \<Table> 的footer属性不为空时，会渲染一个ant-table-footer带背景色的区域，即使没有任何内容，也会有一个32px的padding撑起高度，样式不美观，该commit将其去掉。

![screenshot-20220605-162845](https://user-images.githubusercontent.com/8577164/172042208-318bd04c-5821-49a7-82b4-1fd4d56ba320.png)
